### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/BertNatenstedt/e79c4c6b-f329-482f-b7cd-0ad3207bfd30/d0c73666-e868-4cfa-ace8-14ca8bfe9f48/_apis/work/boardbadge/e1536ce2-6fbd-422a-bfb8-9c2a2e05f397)](https://dev.azure.com/BertNatenstedt/e79c4c6b-f329-482f-b7cd-0ad3207bfd30/_boards/board/t/d0c73666-e868-4cfa-ace8-14ca8bfe9f48/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#17](https://dev.azure.com/BertNatenstedt/e79c4c6b-f329-482f-b7cd-0ad3207bfd30/_workitems/edit/17). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.